### PR TITLE
Make text areas fill area better

### DIFF
--- a/_pages/Animal_info.html
+++ b/_pages/Animal_info.html
@@ -171,11 +171,9 @@ layout: contact_sidebar
     </div>
 
     <div class="js-have-other-followup d-none">
-      <div class="form-row">
-        <div class="form-group">
-          <label for="inputAnimal_types">(if yes to other animals) Please list your other types of animals.</label>
-          <textarea class="form-control" id="inputAnimal_types" rows="3" ></textarea>
-        </div>
+      <div class="form-group">
+        <label for="inputAnimal_types">(if yes to other animals) Please list your other types of animals.</label>
+        <textarea class="form-control" id="inputAnimal_types" rows="3" ></textarea>
       </div>
     </div>
   </div>

--- a/_pages/Help_info.html
+++ b/_pages/Help_info.html
@@ -10,26 +10,23 @@ layout: contact_sidebar
   <div class="progress-bar" role="progressbar" style="width: 14.29%" aria-valuenow="14.29" aria-valuemin="0" aria-valuemax="100"><a href="Animal_info.html">5</a></div>
   <div class="progress-bar" role="progressbar" style="width: 14.29%" aria-valuenow="14.29" aria-valuemin="0" aria-valuemax="100"><a href="Help_info.html">6</a></div>
 </div>
+
 <h2>Tell us how we can help you foster</h2>
-<div class="form-row">
-    <div class="form-group">
-        <label for="inputHelp_foster">Based on what we have available, we may be able to offer some supplies for your foster animal if you need them. Would you like the Austin Animal Center to see if we can help you with supplies for your foster animal (crates, litter, etc.)?</label>
-        <small id="Help_fosterHelpInline" class="text-muted">
-            Optional
-        </small>
-        <textarea class="form-control" id="inputHelp_foster" rows="3" ></textarea>
-    </div>
-</div>
-<div class="form-row">
-    <div class="form-group">
-        <label for="inputAnything_else">Is there anything else you would like us to know?</label>
-        <small id="Anything_elseHelpInline" class="text-muted">
-            Optional
-        </small>
-        <textarea class="form-control" id="inputAnything_else" rows="3" ></textarea>
-    </div>
-</div>
 <form>
+  <div class="form-group">
+      <label for="inputHelp_foster">Based on what we have available, we may be able to offer some supplies for your foster animal if you need them. Would you like the Austin Animal Center to see if we can help you with supplies for your foster animal (crates, litter, etc.)?</label>
+      <small id="Help_fosterHelpInline" class="text-muted">
+          Optional
+      </small>
+      <textarea class="form-control" id="inputHelp_foster" rows="3" ></textarea>
+  </div>
+  <div class="form-group">
+      <label for="inputAnything_else">Is there anything else you would like us to know?</label>
+      <small id="Anything_elseHelpInline" class="text-muted">
+          Optional
+      </small>
+      <textarea class="form-control" id="inputAnything_else" rows="3" ></textarea>
+  </div>
   <a class="btn btn-primary" href="Confirmation.html" role="button">Submit application</a>
   <a class="btn btn-outline-primary" href="Animal_info.html" role="button">Back</a>
 </form>


### PR DESCRIPTION
This addresses #11. 

@juliazbyron, The reason this was happening was because we were using both classes `form-row` & `form-group` to wrap the field label and textarea.

I think `form-row` is meant to be used when you want to put form elements side by side like in this example below. 

![screen shot 2018-02-19 at 5 40 08 pm](https://user-images.githubusercontent.com/5697474/36401266-f76f233a-159b-11e8-8da9-377cabf0519b.png)
[Link to Bootstrap docs for reference](https://getbootstrap.com/docs/4.0/components/forms/#form-row)

